### PR TITLE
Add syntax highlighter, table data, css styles and changes the output folder

### DIFF
--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
@@ -225,7 +225,7 @@ public class HtmlBuilder {
 	}
 
 	public String buildTableHeader() {
-		String[] rowData = new String[]{"Element", "Class", "Location", "CEF", "CEP", "CNF",
+		String[] rowData = new String[]{"Class", "Function", "Location", "CEF", "CEP", "CNF",
 									"CNP", "Suspiciouness"};
 		return wrapData(rowData, "th");
 	}

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
@@ -240,11 +240,17 @@ public class HtmlBuilder {
 
 	public StringBuilder buildExecutionInfo() {
 		StringBuilder strExecutionInfo = new StringBuilder();
+		int total = Jaguar.getnTests();
+		int failed = Jaguar.getnTestsFailed();
+		int success = total - failed;
+
 		return strExecutionInfo.append("<p>Executed Tests: ")
-				.append(Jaguar.getnTests())
-				.append("</p>")
-				.append("<p>Failed Tests: ")
-				.append(Jaguar.getnTestsFailed())
-				.append("</p>");
+				.append(total).append("</p>")
+				.append("<p> Successful Tests: <span class = 'test-success'>")
+				.append(success)
+				.append("</span></p><p>Failed Tests:")
+				.append("<span class = 'test-fail'>")
+				.append(failed)
+				.append("</span></p>");
 	}
 }

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
@@ -57,7 +57,7 @@ public class HtmlBuilder {
 		this.projectBeingTestedDir = projectBeingTestedDir;
 	}
 	
-	public String build() throws IOException, URISyntaxException {
+	public String build() throws IOException {
 		File htmlTemplateFile = new File("br.usp.each.saeg.jaguar.core/src/main/resources/html-output/index.html");
 		String htmlString = FileUtils.readFileToString(htmlTemplateFile);
 		
@@ -104,7 +104,7 @@ public class HtmlBuilder {
 			
 			String codeFromClassTransformedForHtml = transformJavaCodeToDisplayInHtml(codeFromClass, requirementsForThisClass);
 			
-			requirementHtmlList.append("<pre> <code>")
+			requirementHtmlList.append("<pre><code class=\"language-java\">")
 					.append(codeFromClassTransformedForHtml)
 					.append("</code> </pre>");
 			
@@ -128,6 +128,8 @@ public class HtmlBuilder {
 		StringBuilder codeFromClassTransformedForHtml = new StringBuilder();
 		
 		List<String> rowsInJavaCode = Arrays.asList(javaCode.split("\\n"));
+
+		codeFromClassTransformedForHtml.append("<ol class=\"linenumbers\">");
 		
 		for(int rowIndex = 0; rowIndex < rowsInJavaCode.size(); rowIndex++){
 			
@@ -143,7 +145,7 @@ public class HtmlBuilder {
 					return false;
 				}
 			}).findFirst();
-			
+
 			if(optionalAbstractTestRequirementForThisLine.isPresent()){
 				
 				AbstractTestRequirement requirement = optionalAbstractTestRequirementForThisLine.get();
@@ -153,11 +155,12 @@ public class HtmlBuilder {
 						+ "</span>"
 						;
 			}
-			
-			codeFromClassTransformedForHtml.append(codeLine + "<br/>");
-			
+
+			codeFromClassTransformedForHtml.append("<li>")
+					.append(codeLine).append(System.lineSeparator())
+					.append("</li>");
 		}
-		
+
 		
 		return codeFromClassTransformedForHtml.toString();
 	}

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
@@ -4,6 +4,7 @@ import br.usp.each.saeg.jaguar.codeforest.model.Requirement;
 import br.usp.each.saeg.jaguar.core.Jaguar;
 import br.usp.each.saeg.jaguar.core.heuristic.Heuristic;
 import br.usp.each.saeg.jaguar.core.model.core.requirement.AbstractTestRequirement;
+import br.usp.each.saeg.jaguar.core.model.core.requirement.DuaTestRequirement;
 import br.usp.each.saeg.jaguar.core.model.core.requirement.LineTestRequirement;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
@@ -224,14 +225,23 @@ public class HtmlBuilder {
 	}
 
 	public String buildTableHeader() {
-		String[] rowData = new String[]{"Element", "Class", "Line", "CEF", "CEP", "CNF",
+		String[] rowData = new String[]{"Element", "Class", "Location", "CEF", "CEP", "CNF",
 									"CNP", "Suspiciouness"};
 		return wrapData(rowData, "th");
 	}
 
 	public String buildTableRowForLineTestRequirement(AbstractTestRequirement atr) {
+		Integer location = null;
+		if (atr instanceof DuaTestRequirement) {
+			DuaTestRequirement duaRequirement = (DuaTestRequirement) atr;
+			location = duaRequirement.getDef();
+		} else if (atr instanceof LineTestRequirement){
+			LineTestRequirement lineRequirement = (LineTestRequirement) atr;
+			location = lineRequirement.getLineNumber();
+		}
+
 		String[] rowData = new String[]{atr.getClassName(), atr.getMethodSignature(),
-				String.valueOf(atr.getMethodLine()), String.valueOf(atr.getCef()),
+				location.toString(), String.valueOf(atr.getCef()),
 				String.valueOf(atr.getCep()), String.valueOf(atr.getCnf()),
 				String.valueOf(atr.getCnp()), String.valueOf(atr.getSuspiciousness())};
 

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlBuilder.java
@@ -88,11 +88,15 @@ public class HtmlBuilder {
 		requirementHtmlList.append(buildExecutionInfo());
 
 		for (String className : requirementsGroupByClass.keySet()){
-			requirementHtmlList.append("<div class=\"java-class\" id = \"java-class-").append(className).append("\">");
+			requirementHtmlList.append("<div class=\"java-class\" id = \"java-class-")
+					.append(className).append("\">");
+
 			requirementHtmlList.append("<h3>").append(className).append("</h3>");
-			Collection<AbstractTestRequirement> requirementsForThisClass = requirementsGroupByClass.get(className);
-			requirementHtmlList.append(buildHTMLTable(abstractTestRequirementList));
-			requirementHtmlList.append("<div class=\"java-class-code\" id = \"java-class-code").append(className).append("\">");
+
+			requirementHtmlList.append("<div style=\"overflow-x:auto;\">")
+					.append(buildHTMLTable(abstractTestRequirementList))
+					.append("<div class=\"java-class-code\" id = \"java-class-code")
+					.append(className).append("\">");
 			
 			String codeFromClass = getCodeFromAbsolutePath(
 					projectBeingTestedDir.getAbsolutePath()
@@ -101,7 +105,8 @@ public class HtmlBuilder {
 							+ System.getProperty("file.separator") + "java"
 							+ System.getProperty("file.separator") + className + ".java"
 			);
-			
+
+			Collection<AbstractTestRequirement> requirementsForThisClass = requirementsGroupByClass.get(className);
 			String codeFromClassTransformedForHtml = transformJavaCodeToDisplayInHtml(codeFromClass, requirementsForThisClass);
 			
 			requirementHtmlList.append("<pre><code class=\"language-java\">")
@@ -176,30 +181,61 @@ public class HtmlBuilder {
 			tableLines.append(buildTableRowForLineTestRequirement(currentRequirement));
 		}
 
-		return "<table style=\"border:1px solid black;\">" +
-					buildTableHeader() +
-					tableLines +
-				"</table>";
+		return wrapData(new String[] {buildTableHeader(), tableLines.toString()}, "table");
+	}
+
+	public String wrapData(String[] data, String tag) {
+		StringBuilder wrappedData = new StringBuilder();
+		boolean enclosed = false;
+		String open = "<p>";
+		String close = "</p>";
+		String begin = null;
+		String end = null;
+
+		if (tag.equals("th")){
+			open = "<th>";
+			close = "</th>";
+			enclosed = true;
+			begin = "<tr>";
+			end = "</tr>";
+		} else if ( tag.equals("td")) {
+			open = "<td>";
+			close = "</td>";
+			enclosed = true;
+			begin = "<tr>";
+			end = "</tr>";
+		} else if ( tag.equals("table")) {
+			enclosed = true;
+			begin = "<table>";
+			end = "</table>";
+			open = "<tr>";
+			close = "</tr>";
+		}
+
+		for( String line: data) {
+			if (line == null) line ="";
+			wrappedData.append(open).append(line).append(close);
+		}
+
+		if (enclosed)
+			return begin + wrappedData + end;
+
+		return wrappedData.toString();
 	}
 
 	public String buildTableHeader() {
-		return "<tr>" +
-				"<th>" + "Element" + "</th>" +
-				"<th>" + "CEF" + "</th>" +
-				"<th>" + "CEP" + "</th>" +
-				"<th>" + "CNF" + "</th>" +
-				"<th>" + "CNP" + "</th>" +
-				"</tr>";
+		String[] rowData = new String[]{"Element", "Class", "Line", "CEF", "CEP", "CNF",
+									"CNP", "Suspiciouness"};
+		return wrapData(rowData, "th");
 	}
 
 	public String buildTableRowForLineTestRequirement(AbstractTestRequirement atr) {
-		return 	"<tr>" +
-				"<td style=\"border:1px solid black;\">" + atr.getMethodLine() + "</td>" +
-				"<td style=\"border:1px solid black;\">" + atr.getCef() + "</td>" +
-				"<td style=\"border:1px solid black;\">" + atr.getCep() + "</td>" +
-				"<td style=\"border:1px solid black;\">" + atr.getCnf() + "</td>" +
-				"<td style=\"border:1px solid black;\">" + atr.getCnp() + "</td>" +
-				"</tr>";
+		String[] rowData = new String[]{atr.getClassName(), atr.getMethodSignature(),
+				String.valueOf(atr.getMethodLine()), String.valueOf(atr.getCef()),
+				String.valueOf(atr.getCep()), String.valueOf(atr.getCnf()),
+				String.valueOf(atr.getCnp()), String.valueOf(atr.getSuspiciousness())};
+
+		return wrapData(rowData, "td");
 	}
 
 	public StringBuilder buildExecutionInfo() {

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlWriter.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/html/HtmlWriter.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class HtmlWriter {
 	
 	private static final Logger logger = LoggerFactory.getLogger("JaguarLogger");
-	private static final String FOLDER_NAME = ".jaguar";
+	private static final String FOLDER_NAME = "Reports";
 	
 	private final List<AbstractTestRequirement> testRequirements;
 	private final Heuristic currentHeuristic;

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/xml/flat/FlatXmlWriter.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/xml/flat/FlatXmlWriter.java
@@ -16,7 +16,7 @@ import br.usp.each.saeg.jaguar.codeforest.model.Requirement.Type;
 public class FlatXmlWriter {
 
 	private static Logger logger = LoggerFactory.getLogger("JaguarLogger");
-	private static final String FOLDER_NAME = ".jaguar";
+	private static final String FOLDER_NAME = "Reports";
 	
 	private ArrayList<AbstractTestRequirement> testRequirements;
 	private Heuristic currentHeuristic;

--- a/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/xml/hierarchical/HierarchicalXmlWriter.java
+++ b/br.usp.each.saeg.jaguar.core/src/main/java/br/usp/each/saeg/jaguar/core/output/xml/hierarchical/HierarchicalXmlWriter.java
@@ -16,7 +16,7 @@ import br.usp.each.saeg.jaguar.codeforest.model.Requirement.Type;
 public class HierarchicalXmlWriter {
 
 	private static Logger logger = LoggerFactory.getLogger("JaguarLogger");
-	private static final String FOLDER_NAME = ".jaguar";
+	private static final String FOLDER_NAME = "Reports";
 
 	private ArrayList<AbstractTestRequirement> testRequirements;
 	private Heuristic currentHeuristic;

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/index.html
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/index.html
@@ -14,6 +14,9 @@
             background-color:rgba(227, 27, 27, 0.5);
         }
     </style>
+    <link rel="stylesheet" href="../../br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-light.css">
+    <!--<script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>-->
+
 </head>
 <body>
 
@@ -27,7 +30,8 @@
     <div class="testRequirements">
         $testRequirementsList$
     </div>
-    
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
+    <script>hljs.highlightAll(); </script>
     
 </body>
 </html>

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/index.html
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/index.html
@@ -3,35 +3,27 @@
 <head>
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-    <title>$pageTitle$</title>
+    <title>JAGUAR REPORT</title>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
-    <style>
-        .executionConfigs{
-            margin-bottom: 20px;
-        }
-        
-        .red{
-            background-color:rgba(227, 27, 27, 0.5);
-        }
-    </style>
+    <link rel="stylesheet" href="../../br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css">
     <link rel="stylesheet" href="../../br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-light.css">
     <!--<script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>-->
 
 </head>
 <body>
+    <div class = "wrapper">
+        <h1>Jaguar report</h1>
 
-    <h1>Jaguar report</h1>
+        <div class="executionConfigs">
+            <div><span>Heuristic: </span><span >$heuristic$</span></div>
+            <div><span>Requirement type: </span><span >$requirementType$</span></div>
+        </div>
 
-    <div class="executionConfigs">
-        <div><span>Heuristic: </span><span >$heuristic$</span></div>
-        <div><span>Requirement type: </span><span >$requirementType$</span></div>
+        <div class="testRequirements">
+            $testRequirementsList$
+        </div>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
+        <script>hljs.highlightAll(); </script>
     </div>
-
-    <div class="testRequirements">
-        $testRequirementsList$
-    </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
-    <script>hljs.highlightAll(); </script>
-    
 </body>
 </html>

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-dark.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-dark.css
@@ -1,0 +1,129 @@
+/*!
+  Theme: StackOverflow Dark
+  Description: Dark theme as used on stackoverflow.com
+  Author: stackoverflow.com
+  Maintainer: @Hirse
+  Website: https://github.com/StackExchange/Stacks
+  License: MIT
+  Updated: 2021-05-15
+
+  Updated for @stackoverflow/stacks v0.64.0
+  Code Blocks: /blob/v0.64.0/lib/css/components/_stacks-code-blocks.less
+  Colors: /blob/v0.64.0/lib/css/exports/_stacks-constants-colors.less
+*/
+
+pre, .hljs {
+  /* var(--highlight-color) */
+  color: #ffffff;
+  /* var(--highlight-bg) */
+  background: #1c1b1b;
+  font-size: 14 px;
+}
+
+.hljs-subst {
+  /* var(--highlight-color) */
+  color: #ffffff;
+}
+
+.hljs-comment {
+  /* var(--highlight-comment) */
+  color: #999999;
+  font-weight: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-meta .hljs-keyword,
+.hljs-doctag,
+.hljs-section {
+  /* var(--highlight-keyword) */
+  color: #88aece;
+  font-weight: bolder;
+}
+
+.hljs-attr {
+  /* var(--highlight-attribute); */
+  color: #88aece;
+}
+
+.hljs-attribute {
+  /* var(--highlight-symbol) */
+  color: #c59bc1;
+}
+
+.hljs-name,
+.hljs-type,
+.hljs-number,
+.hljs-selector-id,
+.hljs-quote,
+.hljs-template-tag {
+  /* var(--highlight-namespace) */
+  color: #f08d49;
+}
+
+.hljs-selector-class {
+  /* var(--highlight-keyword) */
+  color: #88aece;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-selector-attr {
+  /* var(--highlight-variable) */
+  color: #b5bd68;
+}
+
+.hljs-meta,
+.hljs-selector-pseudo {
+  /* var(--highlight-keyword) */
+  color: #88aece;
+}
+
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  /* var(--highlight-literal) */
+  color: #f08d49;
+}
+
+.hljs-bullet,
+.hljs-code {
+  /* var(--highlight-punctuation) */
+  color: #cccccc;
+}
+
+.hljs-meta .hljs-string {
+  /* var(--highlight-variable) */
+  color: #b5bd68;
+}
+
+.hljs-deletion {
+  /* var(--highlight-deletion) */
+  color: #de7176;
+}
+
+.hljs-addition {
+  /* var(--highlight-addition) */
+  color: #76c490;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-formula,
+.hljs-operator,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-dark.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-dark.css
@@ -28,7 +28,7 @@ pre, .hljs {
 .hljs-comment {
   /* var(--highlight-comment) */
   color: #999999;
-  font-weight: italic;
+  font-style: italic;
 }
 
 .hljs-keyword,

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-light.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-light.css
@@ -28,7 +28,7 @@ pre, .hljs {
 .hljs-comment {
   /* var(--highlight-comment) */
   color: #656e77;
-  font-weight: italic;
+  font-style: italic;
 }
 
 .hljs-keyword,

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-light.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/stackoverflow-light.css
@@ -1,0 +1,133 @@
+/*!
+  Theme: StackOverflow Light
+  Description: Light theme as used on stackoverflow.com
+  Author: stackoverflow.com
+  Maintainer: @Hirse
+  Website: https://github.com/StackExchange/Stacks
+  License: MIT
+  Updated: 2021-05-15
+
+  Updated for @stackoverflow/stacks v0.64.0
+  Code Blocks: /blob/v0.64.0/lib/css/components/_stacks-code-blocks.less
+  Colors: /blob/v0.64.0/lib/css/exports/_stacks-constants-colors.less
+*/
+
+pre, .hljs {
+  /* var(--highlight-color) */
+  color: #2f3337;
+  /* var(--highlight-bg) */
+  background: #f6f6f6;
+  font-size: 14 px;
+}
+
+.hljs-subst {
+  /* var(--highlight-color) */
+  color: #2f3337;
+}
+
+.hljs-comment {
+  /* var(--highlight-comment) */
+  color: #656e77;
+  font-weight: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-meta .hljs-keyword,
+.hljs-doctag,
+.hljs-section {
+  /* var(--highlight-keyword) */
+  color: #015692;
+  font-weight: bolder;
+}
+
+.hljs-attr {
+  /* var(--highlight-attribute); */
+  color: #015692;
+}
+
+.hljs-attribute {
+  /* var(--highlight-symbol) */
+  color: #803378;
+}
+
+.hljs-name,
+.hljs-type,
+.hljs-number,
+.hljs-selector-id,
+.hljs-quote,
+.hljs-template-tag {
+  /* var(--highlight-namespace) */
+  color: #b75501;
+}
+
+.hljs-selector-class {
+  /* var(--highlight-keyword) */
+  color: #015692;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-selector-attr {
+  /* var(--highlight-variable) */
+  color: #54790d;
+}
+
+.hljs-meta,
+.hljs-selector-pseudo {
+  /* var(--highlight-keyword) */
+  color: #015692;
+}
+
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  /* var(--highlight-literal) */
+  color: #b75501;
+}
+
+.hljs-bullet,
+.hljs-code {
+  /* var(--highlight-punctuation) */
+  color: #535a60;
+}
+
+.hljs-meta .hljs-string {
+  /* var(--highlight-variable) */
+  color: #54790d;
+}
+
+.hljs-deletion {
+  /* var(--highlight-deletion) */
+  color: #c02d2e;
+}
+
+.hljs-addition {
+  /* var(--highlight-addition) */
+  color: #2f6f44;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-formula,
+.hljs-operator,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}
+
+ul li::marker {
+   white-space: normal;
+}

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
@@ -43,3 +43,10 @@ th {
     text-transform: uppercase;
 }
 
+.test-success {
+    color: green;
+}
+
+.test-fail {
+    color: red;
+}

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
@@ -1,0 +1,42 @@
+body{
+    color: black;
+    font-size: 16px;
+    width: 100%;
+}
+
+.wrapper {
+    width: 80%;
+}
+
+.executionConfigs{
+    margin-bottom: 20px;
+    width: 100%;
+}
+
+.testRequirements {
+    width: 100%;
+}
+
+.red{
+    background-color:rgba(227, 27, 27, 0.5);
+}
+
+table, th, td {
+    padding: 2px;
+    text-align: left;
+    border: 1px solid black;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+tr:hover {
+    background-color: azure;
+}
+
+pre {
+    top: 30px;
+    overflow:auto;
+    font-size: 14px;
+}
+
+

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
@@ -39,4 +39,7 @@ pre {
     font-size: 14px;
 }
 
+th {
+    text-transform: uppercase;
+}
 

--- a/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
+++ b/br.usp.each.saeg.jaguar.core/src/main/resources/html-output/style.css
@@ -30,7 +30,7 @@ table, th, td {
 }
 
 tr:hover {
-    background-color: azure;
+    background-color: aquamarine;
 }
 
 pre {


### PR DESCRIPTION
This pull adds a **syntax highlighter to the java code, data to the table, and some css stylesheets**. 

- I've chosen[ Highlight.js](https://highlightjs.org/) as the project syntax highlighter, as it's more than enough for the reports, widely used and well accepted. (ex. stack overflow uses it)
- Changed the reports output folder to 'Reports' and no longer the invisible '.jaguar' to help the user find the reports more easily. 
- Added data to the tables, although there is no hierarchy yet, as there are some definitions to be made by the team.
- Added style sheets in separate .css files. I really think this is the best choice as the code will only grown and the highlighter stylesheet would probably be in a separate file anyway. If this is the right path to this project or not, we might want to consider the discussion at jacoco [here](https://github.com/jacoco/jacoco/issues/472)